### PR TITLE
Add an install target and basic README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,14 @@ set_target_properties(link PROPERTIES CXX_STANDARD 23)
 target_include_directories(link PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/Include)
 target_link_libraries(link PUBLIC ssl)
 
+
+install(TARGETS link
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Include/
+        DESTINATION /usr/local/include
+        FILES_MATCHING PATTERN "*.hpp")
+
 # Test
 file(GLOB_RECURSE TEST_SOURCES Test/*.cpp)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Link
+Link is a web library for C++ built with a focus of speed.
+
+# Build and Install Link
+Make sure you install CMake, GCC, Ninja, and OpenSSL.
+
+>   ------------------------------------------------------------------------------
+>
+>   **NOTE**: *Ninja is optional as you can also use Make as your build system but
+>   this is untested and Ninja is known to be a much faster build system.*
+>
+>   ------------------------------------------------------------------------------
+
+```
+$ mkdir build && cd build
+$ cmake -GNinja ..
+$ ninja && ninja install
+```


### PR DESCRIPTION
Not directly pushing this to the repository since I'm not sure if Levi wants any if this or not.

This commit just adds a basic README with build instructions and adds the install target back into the CMakeLists.txt.

Signed-off-by: Ariston Lorenzo <me@ariston.dev>