### PR TITLE
docs: Added a beginners guide and security policy

### DIFF
--- a/docs/beginners-guide.md
+++ b/docs/beginners-guide.md
@@ -1,0 +1,33 @@
+Beginners Guide to Link
+=======================
+
+Introduction
+------------
+Link is a web server library built with a focus of speed for C++. Link is meant
+to be a relatively easy framework to use and is considered the *ExpressJS* for
+C++ developers. 
+
+A New Project (with linkproj)
+-----------------------------
+Once you have installed Link, you can clone the [aristonl/linkproj](https://github.com/aristonl/linkproj)
+repository which is meant to be a simple template you can use to quickly setup
+a Link-based project. To build, all you need to do is:
+
+	mkdir build && cd build
+	cmake .. 
+	make
+	./website
+
+Or you can also use ninja like so:
+	
+	mkdir build && cd build
+	cmake -GNinja ..
+	ninja
+	./website
+
+*linkproj* will run on port 3000 by default. You can start editing your site in
+`www/` and handle all C++ related code in `src/`.
+
+A New Project (from scratch)
+----------------------------
+> **TODO**: *It's probably best to get linkproj working beforehand so we can use it as a basis for this section*

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,18 @@
+Security Policies
+=================
+We take security in Link very seriously so it is important that if a security
+issue has been detected, we will be able to handle the situation as quickly as
+possible
+
+Reporting a Security Issue
+--------------------------
+
+### 1. Creating a public issue
+The first way you can report a security bug is by creating an issue on GitHub
+and explaining the details there, or you can also email the *hydra-inferno*
+mailing list at [hydra-inferno@googlegroups.com](mailto:hydra-inferno@googlegroups.com).
+
+### 2. Disclosing the issue privately
+You can also report a security issue privately via emailing [Levi Hicks](mailto:me@levicowan.dev)
+or direct messaging Levi on Discord (FiRe#9047).
+


### PR DESCRIPTION
It might be best for me to commit the security policy directly to this branch and create a PR solely for the beginner's guide but honestly, I was too lazy to do so and the security policy commit is after the beginners guide commit and we all know *rebasing* isn't fun 👎🏽 . Anyways, it might be best to hold off on merging this since it might be better to commit an actual finished beginner's guide rather than a half-completed one. I'll probably wait until Levi or I release the v2.0rc1 pre-release tag since by then, I should have a good glimpse of what a Link v2.0-based project would look like.

Signed-off-by: Ariston Lorenzo <me@ariston.dev>

---

Ariston Lorenzo (2):
      docs: Add a beginners guide
      docs: Add a security policy
